### PR TITLE
Fix path yet again

### DIFF
--- a/eid-applet-core/src/main/java/be/fedict/eid/applet/sc/LibJ2PCSCGNULinuxFix.java
+++ b/eid-applet-core/src/main/java/be/fedict/eid/applet/sc/LibJ2PCSCGNULinuxFix.java
@@ -125,7 +125,7 @@ public final class LibJ2PCSCGNULinuxFix {
 	private static String addMultiarchPath(final String libPath,
 			final String suffix) {
 		String retval = extendLibraryPath(libPath, "/lib/" + suffix);
-		return extendLibraryPath(libPath, "/usr/lib/" + suffix);
+		return extendLibraryPath(retval, "/usr/lib/" + suffix);
 	}
 
 	/*


### PR DESCRIPTION
It turns out the Ubuntu packages differ from the Debian ones, due to
Debian bug#531592 and a difference of opinion between the Debian
maintainer of PC/SC and the Ubuntu maintainers. As such, if we want to
work on both distributions, we need to add both directories.

Hardcoding paths is silly, Oracle.

Note: compile-tested, not functionally tested (due to "I don't have a test environment"). If you put this live, I'd be happy to do a test login or some such.
